### PR TITLE
Fix bug -> Click more than 2 cards within 500ms waiting will cause problem.

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,30 +71,29 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   //check for matches
-  function checkForMatch() {
+  function checkForMatch(names, ids) {
     const cards = document.querySelectorAll('img')
-    const optionOneId = cardsChosenId[0]
-    const optionTwoId = cardsChosenId[1]
+    const optionOneId = ids[0]
+    const optionTwoId = ids[1]
     
     if(optionOneId == optionTwoId) {
       cards[optionOneId].setAttribute('src', 'images/blank.png')
       cards[optionTwoId].setAttribute('src', 'images/blank.png')
       alert('You have clicked the same image!')
     }
-    else if (cardsChosen[0] === cardsChosen[1]) {
+    else if (names[0] === names[1]) {
       alert('You found a match')
       cards[optionOneId].setAttribute('src', 'images/white.png')
       cards[optionTwoId].setAttribute('src', 'images/white.png')
       cards[optionOneId].removeEventListener('click', flipCard)
       cards[optionTwoId].removeEventListener('click', flipCard)
-      cardsWon.push(cardsChosen)
+      cardsWon.push(names)
     } else {
       cards[optionOneId].setAttribute('src', 'images/blank.png')
       cards[optionTwoId].setAttribute('src', 'images/blank.png')
       alert('Sorry, try again')
     }
-    cardsChosen = []
-    cardsChosenId = []
+
     resultDisplay.textContent = cardsWon.length
     if  (cardsWon.length === cardArray.length/2) {
       resultDisplay.textContent = 'Congratulations! You found them all!'
@@ -107,8 +106,12 @@ document.addEventListener('DOMContentLoaded', () => {
     cardsChosen.push(cardArray[cardId].name)
     cardsChosenId.push(cardId)
     this.setAttribute('src', cardArray[cardId].img)
-    if (cardsChosen.length ===2) {
-      setTimeout(checkForMatch, 500)
+    if (cardsChosen.length === 2) {
+      let names = [...cardsChosen]
+      let ids = [...cardsChosenId]
+      cardsChosen = []
+      cardsChosenId = []  
+      setTimeout(() => checkForMatch(names, ids), 500)
     }
   }
 


### PR DESCRIPTION
In the original version, Due to `checkForMatch` will run after 500ms delay, so if click more than 2 cards within 500ms, the `cardsChosen.length` will longer than 2.

And, the `checkForMatch` will run only on condition "cardsChosen.length === 2", so cardsChosen[2], cardsChosen[3] maybe after will not trigger `checkForMatch`.

This commit move the `cardsChosen = []` and `cardsChosenId = []` out of `checkForMatch` and put them into `flipCard` before `checkForMatch` runs, and use copy to replace them into `checkForMatch`.